### PR TITLE
Fixes compatibility with newer versions of httpoison.

### DIFF
--- a/lib/hubspot/http/client.ex
+++ b/lib/hubspot/http/client.ex
@@ -39,6 +39,7 @@ defmodule Hubspot.HTTP.Client do
   end
 
   defp process_request_options([]), do: []
+  defp process_request_options([params: _]=options), do: options
   defp process_request_options(params) do
     [params: params]
   end


### PR DESCRIPTION
In newer versions of httpoison, process_request_options/1 is now a callback for classes that use HTTPoison.Base. As a result, in HTTPoison 0.11.1, Hubspot.HTTP.Client.process_request_options was being called twice, which resulted in: [params: [params: ___]].  Since 0.9 still needs this call, I resolved the issue by pattern matching to prevent the double-nesting

fixes #1 