### PR TITLE
do not encode an empty request body

### DIFF
--- a/lib/hubspot/http/client.ex
+++ b/lib/hubspot/http/client.ex
@@ -44,6 +44,7 @@ defmodule Hubspot.HTTP.Client do
     [params: params]
   end
 
+  defp process_request_body(""), do: ""
   defp process_request_body(body) do
     body |> Poison.Encoder.encode("")
   end


### PR DESCRIPTION
Empty GET requests were passing: "\"\"" in to their request body, and it was breaking every other call (why every other call is a complete mystery to me).  Anyway, this just leaves empty request bodies alone, the way HTTPoison.get! does

Fixes #3 