### PR TITLE
Decode body with a ! operator to simplify the response being returned

### DIFF
--- a/lib/hubspot/http/client.ex
+++ b/lib/hubspot/http/client.ex
@@ -50,6 +50,6 @@ defmodule Hubspot.HTTP.Client do
   end
 
   defp process_response_body(body) do
-    body |> Poison.decode
+    body |> Poison.decode!
   end
 end


### PR DESCRIPTION
Changes the response body from:
{:ok, %{}}
to:
%{}

The thinking is that Hubspot should always return either valid json. So this just makes the output a little easier to use. 

**Note** This is a breaking change! It'd be a good idea to version bump for this, if accepted.